### PR TITLE
New team picks based on KD ratio, popularity, missing roles

### DIFF
--- a/src/data/heros_rank.json
+++ b/src/data/heros_rank.json
@@ -1,0 +1,134 @@
+[
+  {
+    "name": "Soldier: 76",
+    "role": "Offense",
+    "icon": "soldier.png",
+    "roleRank": 3
+  },
+  {
+    "name": "Reaper",
+    "role": "Offense",
+    "icon": "reaper.png",
+    "roleRank": 1
+  },
+  {
+    "name": "Pharah",
+    "role": "Offense",
+    "icon": "pharah.png",
+    "roleRank": 6
+  },
+  {
+    "name": "Genji",
+    "role": "Offense",
+    "icon": "genji.png",
+    "roleRank": 2
+  },
+  {
+    "name": "McCree",
+    "role": "Offense",
+    "icon": "mccree.png",
+    "roleRank": 5
+  },
+  {
+    "name": "Tracer",
+    "role": "Offense",
+    "icon": "tracer.png",
+    "roleRank": 4
+  },
+  {
+    "name": "Bastion",
+    "role": "Defense",
+    "icon": "bastion.png",
+    "roleRank": 4
+  },
+  {
+    "name": "Hanzo",
+    "role": "Defense",
+    "icon": "hanzo.png",
+    "roleRank": 3
+  },
+  {
+    "name": "Junkrat",
+    "role": "Defense",
+    "icon": "junkrat.png",
+    "roleRank": 1
+  },
+  {
+    "name": "Mei",
+    "role": "Defense",
+    "icon": "mei.png",
+    "roleRank": 2
+  },
+  {
+    "name": "Torbjörn",
+    "role": "Defense",
+    "icon": "torbjorn.png",
+    "roleRank": 5
+  },
+  {
+    "name": "Widowmaker",
+    "role": "Defense",
+    "icon": "widowmaker.png",
+    "roleRank": 6
+  },
+  {
+    "name": "D.Va",
+    "role": "Tank",
+    "icon": "dva.png",
+    "roleRank": 4
+  },
+  {
+    "name": "Reinhardt",
+    "role": "Tank",
+    "icon": "reinhardt.png",
+    "roleRank": 2
+  },
+  {
+    "name": "Roadhog",
+    "role": "Tank",
+    "icon": "roadhog.png",
+    "roleRank": 3
+  },
+  {
+    "name": "Winston",
+    "role": "Tank",
+    "icon": "winston.png",
+    "roleRank": 5
+  },
+  {
+    "name": "Zarya",
+    "role": "Tank",
+    "icon": "zarya.png",
+    "roleRank": 1
+  },
+  {
+    "name": "Ana",
+    "role": "Support",
+    "icon": "ana.png",
+    "roleRank": 4
+  },
+  {
+    "name": "Lúcio",
+    "role": "Support",
+    "icon": "lucio.png",
+    "roleRank": 1
+  },
+  {
+    "name": "Mercy",
+    "role": "Support",
+    "icon": "mercy.png",
+    "roleRank": 3
+  },
+  {
+    "name": "Symmetra",
+    "role": "Support",
+    "icon": "symmetra.png",
+    "roleRank": 5
+  },
+  {
+    "name": "Zenyatta",
+    "role": "Support",
+    "icon": "zenyatta.png",
+    "roleRank": 2
+  }
+]

--- a/src/lib/sat.test.js
+++ b/src/lib/sat.test.js
@@ -1,4 +1,3 @@
-import Logic from 'logic-solver';
 import flatten from 'lodash/flatten';
 import uniq from 'lodash/uniq';
 import difference from 'lodash/difference';
@@ -6,6 +5,7 @@ import sortBy from 'lodash/sortBy';
 
 import counters from '../data/counters.json';
 import heros from '../data/heros.json';
+import herosRanks from '../data/heros_rank.json';
 
 function getTeamPicksV2(teamPicks, competitive) {
   const allHeros = heros.map((hero) => hero.name);
@@ -69,7 +69,7 @@ function getTeamPicksV3(teamPicks, competitive) {
 }
 
 
-function getTeamPicks(teamPicks, competitive) {
+function getTeamPicksByHardCounter(teamPicks, competitive) {
   const allHeros = heros.map((hero) => hero.name);
 
   const teamHardCounters = uniq(flatten(teamPicks.map((heroName) => {
@@ -79,12 +79,12 @@ function getTeamPicks(teamPicks, competitive) {
       .map((counter) => counter.enemy);
   })));
 
-  const uncountersHeros = difference(allHeros, teamHardCounters);
+  const uncounteredHeros = difference(allHeros, teamHardCounters);
   const notPicked = difference(allHeros, competitive ? teamPicks : []);
 
   const scores = notPicked.map((heroName) => {
     const numHardCounters = counters.reduce((prev, counter) => {
-      if (counter.you === heroName && counter.score === 2 && uncountersHeros.indexOf(counter.enemy) !== -1) {
+      if (counter.you === heroName && counter.score === 2 && uncounteredHeros.indexOf(counter.enemy) !== -1) {
         return prev + 1;
       }
       return prev;
@@ -92,23 +92,64 @@ function getTeamPicks(teamPicks, competitive) {
 
     return {
       score: numHardCounters,
-      heroName,
+      heroName
     };
   });
 
   return sortBy(scores, 'score').reverse();
 }
 
+function getTeamPicksByHardCounterPrime(teamPicks, competitive) {
+  // distinguishes between heros with same score based on their
+  // rank relative to the other heros with the same role.
+  // rank is determined by different factors depending on the role
+  // (all based on competitive play stats from masteroverwatch)
+  // the rank data is in heros_rank.json
+  // Offense - rank by KD ratio
+  // every other role - rank by popularity
+  // TODO: test ranking by different combinations of factors
+
+  const allHeros = heros.map((hero) => hero.name);
+
+  const teamHardCounters = uniq(flatten(teamPicks.map((heroName) => {
+    return counters
+      .filter((counter) => counter.you === heroName)
+      .filter((counter) => counter.score === 2)
+      .map((counter) => counter.enemy);
+  })));
+  
+  const teamRoles = uniq(teamPicks.map((heroName) => heros.filter((hero) => hero.name == heroName)[0].role));
+
+  const uncounteredHeros = difference(allHeros, teamHardCounters);
+
+  const scores = sortBy(herosRanks.map((hero) => {
+    const numHardCounters = counters.reduce((prev, counter) => {
+      if (counter.you === hero.name && counter.score === 2 && uncounteredHeros.indexOf(counter.enemy) !== -1) {
+        return prev + 1;
+      }
+      return prev;
+    }, 0);
+    
+    const roleRank = 10 - hero.roleRank;
+    const teamIsMissingRole = teamRoles.indexOf(hero.role) === -1;
+    const missingRoleBonus = teamIsMissingRole ? 1 : 0;
+    
+    return {
+      score: numHardCounters + roleRank + missingRoleBonus,
+      name: hero.name,
+      role: hero.role,
+    };
+  }), 'score').reverse();
+  
+  
+  return scores;
+}
+
 
 
 describe('sat', () => {
   fit('should asdf', () => {
-    console.log(getTeamPicks(['Tracer', 'Junkrat', 'Hanzo', 'Mei', 'Bastion', 'Reinhardt'], false))
-    // console.log(getTeamPicksV2(teamPicks, false))
-    console.log(getTeamPicksV3(['Tracer', 'Junkrat', 'Pharah', 'McCree', 'Mei', 'Bastion'], false))
-
-    // expect(getTeamPicks(['Pharah', 'D.Va', 'D.Va', 'D.Va', 'D.Va', 'D.Va'], false)).toMatchSnapshot();
-
+    console.log(getTeamPicksByHardCounterPrime(['Reinhardt', 'Reaper', 'Tracer'], false));
   });
 
 });


### PR DESCRIPTION
I made a modified version of getTeamPicks (which I call `getTeamPicksByHardCounter` in this version) which considers stats from Master Overwatch as well as the roles missing from the current team picks.

Heroes are ranked from 1 to n (lower is better) based on KD ratio for Offense heroes and popularity for every other role based on the stats from Competitive Play in Master Overwatch. This differentiates heros in the same role with the same number of hard counters.

Also, we give the hero's score a bonus if their role is not currently represented in the current team picks.