### PR TITLE
Adjust scores to satisfy role-specific team comp

### DIFF
--- a/src/components/Calculator.js
+++ b/src/components/Calculator.js
@@ -12,6 +12,7 @@ import {
   getTopScores,
   getTeamPicksByHardCounter,
   getTeamPicksByHardCounterPrime,
+  getTeamPicksByHardCounterFlexRoles,
 } from '../lib/undersight';
 import './Calculator.css';
 
@@ -87,7 +88,7 @@ export default class Calculator extends Component {
         title: 'Counters based on your team + Missing Roles + Master Overwatch Stats',
         description: (
           <div className="Description">
-            <div className="Overview">Input: Enemy Team, Output: Your Team</div>
+            <div className="Overview">Input: Your Team, Output: Your Team</div>
             <div className="Details">
               <p>This recommends heros that counter widest variety of enemies. It also considers stats (popularity, KD ratio) from <a href="http://masteroverwatch.com/heroes/pc/global/mode/ranked" target="_blank">Master Overwatch</a> and the missing roles on your team. Use this before a match starts.</p>
               <p>A higher score is better.</p>
@@ -95,6 +96,32 @@ export default class Calculator extends Component {
           </div>
         ),
         scores: getTeamPicksByHardCounterPrime(counters, heros, herosRanks, nonEmptyPicks),
+      },
+      {
+        title: 'Counters based on your team + Flexible Missing Roles (3 Tank, 3 DPS) + Master Overwatch Stats',
+        description: (
+          <div className="Description">
+            <div className="Overview">Input: Your Team, Output: Your Team</div>
+            <div className="Details">
+              <p>This recommends heros that counter widest variety of enemies. It also considers stats (popularity, KD ratio) from <a href="http://masteroverwatch.com/heroes/pc/global/mode/ranked" target="_blank">Master Overwatch</a> and the missing roles on your team. Assumes you want 3 tanks and 3 DPS heroes. Use this before a match starts.</p>
+              <p>A higher score is better.</p>
+            </div>
+          </div>
+        ),
+        scores: getTeamPicksByHardCounterFlexRoles(counters, heros, herosRanks, nonEmptyPicks, {tank: 3, dps: 3, support: 0}),
+      },
+      {
+        title: 'Counters based on your team + Flexible Missing Roles (2 Tank, 2 DPS, 2 Support) + Master Overwatch Stats',
+        description: (
+          <div className="Description">
+            <div className="Overview">Input: Your Team, Output: Your Team</div>
+            <div className="Details">
+              <p>This recommends heros that counter widest variety of enemies. It also considers stats (popularity, KD ratio) from <a href="http://masteroverwatch.com/heroes/pc/global/mode/ranked" target="_blank">Master Overwatch</a> and the missing roles on your team. Assumes you want 2 tanks, 2 supports, and 3 DPS heroes. Use this before a match starts.</p>
+              <p>A higher score is better.</p>
+            </div>
+          </div>
+        ),
+        scores: getTeamPicksByHardCounterFlexRoles(counters, heros, herosRanks, nonEmptyPicks, {tank: 2, dps: 2, support: 2}),
       },
     ];
 

--- a/src/data/heros_ranks.json
+++ b/src/data/heros_ranks.json
@@ -2,132 +2,154 @@
   {
     "name": "Soldier: 76",
     "role": "Offense",
+    "teamRole": "dps",
     "icon": "soldier.png",
     "roleRank": 3
   },
   {
     "name": "Reaper",
     "role": "Offense",
+    "teamRole": "dps",
     "icon": "reaper.png",
     "roleRank": 1
   },
   {
     "name": "Pharah",
     "role": "Offense",
+    "teamRole": "dps",
     "icon": "pharah.png",
     "roleRank": 6
   },
   {
     "name": "Genji",
     "role": "Offense",
+    "teamRole": "dps",
     "icon": "genji.png",
     "roleRank": 2
   },
   {
     "name": "McCree",
     "role": "Offense",
+    "teamRole": "dps",
     "icon": "mccree.png",
     "roleRank": 5
   },
   {
     "name": "Tracer",
     "role": "Offense",
+    "teamRole": "dps",
     "icon": "tracer.png",
     "roleRank": 4
   },
   {
     "name": "Bastion",
     "role": "Defense",
+    "teamRole": "dps",
     "icon": "bastion.png",
     "roleRank": 4
   },
   {
     "name": "Hanzo",
     "role": "Defense",
+    "teamRole": "dps",
     "icon": "hanzo.png",
     "roleRank": 3
   },
   {
     "name": "Junkrat",
     "role": "Defense",
+    "teamRole": "dps",
     "icon": "junkrat.png",
     "roleRank": 1
   },
   {
     "name": "Mei",
     "role": "Defense",
+    "teamRole": "support",
     "icon": "mei.png",
     "roleRank": 2
   },
   {
     "name": "Torbjörn",
     "role": "Defense",
+    "teamRole": "dps",
     "icon": "torbjorn.png",
     "roleRank": 5
   },
   {
     "name": "Widowmaker",
     "role": "Defense",
+    "teamRole": "dps",
     "icon": "widowmaker.png",
     "roleRank": 6
   },
   {
     "name": "D.Va",
     "role": "Tank",
+    "teamRole": "tank",
     "icon": "dva.png",
     "roleRank": 4
   },
   {
     "name": "Reinhardt",
     "role": "Tank",
+    "teamRole": "tank",
     "icon": "reinhardt.png",
     "roleRank": 2
   },
   {
     "name": "Roadhog",
     "role": "Tank",
+    "teamRole": "tank",
     "icon": "roadhog.png",
     "roleRank": 3
   },
   {
     "name": "Winston",
     "role": "Tank",
+    "teamRole": "tank",
     "icon": "winston.png",
     "roleRank": 5
   },
   {
     "name": "Zarya",
     "role": "Tank",
+    "teamRole": "tank",
     "icon": "zarya.png",
     "roleRank": 1
   },
   {
     "name": "Ana",
     "role": "Support",
+    "teamRole": "support",
     "icon": "ana.png",
     "roleRank": 4
   },
   {
     "name": "Lúcio",
     "role": "Support",
+    "teamRole": "support",
     "icon": "lucio.png",
     "roleRank": 1
   },
   {
     "name": "Mercy",
     "role": "Support",
+    "teamRole": "support",
     "icon": "mercy.png",
     "roleRank": 3
   },
   {
     "name": "Symmetra",
     "role": "Support",
+    "teamRole": "support",
     "icon": "symmetra.png",
     "roleRank": 5
   },
   {
     "name": "Zenyatta",
     "role": "Support",
+    "teamRole": "support",
     "icon": "zenyatta.png",
     "roleRank": 2
   }

--- a/src/lib/undersight.test.js
+++ b/src/lib/undersight.test.js
@@ -5,6 +5,7 @@ import {
   getHeroCounters,
   getTeamPicksByHardCounter,
   getTeamPicksByHardCounterPrime,
+  getTeamPicksByHardCounterFlexRoles,
 } from './undersight';
 import allCountersJSON from '../data/counters.json';
 import herosJSON from '../data/heros.json';
@@ -54,6 +55,15 @@ describe('undersight', () => {
   describe('getTeamPicksByHardCounterPrime', () => {
     it('should return team picks', () => {
       expect(getTeamPicksByHardCounterPrime(allCountersJSON, herosJSON, herosRanksJSON, ['Genji', 'Junkrat', 'Roadhog', 'Zenyatta', 'Hanzo', 'Reaper'], false)).toMatchSnapshot();
+    });
+  });
+  
+  describe('getTeamPicksByHardCounterFlexRoles', () => {
+    fit('should return team picks', () => {
+      const teamPicks = ['Tracer', 'Junkrat', 'Zarya', 'Reinhardt'];
+      const roleCountGoal = {tank: 3, dps: 3, support: 0};
+      const newPicks = getTeamPicksByHardCounterFlexRoles(allCountersJSON, herosJSON, herosRanksJSON, teamPicks, roleCountGoal);
+      console.log(newPicks);
     });
   });
 });


### PR DESCRIPTION
This new algorithm adjusts scores based on a given team composition and current team picks. I already added the algorithms to the `Calculator` component so you can try it out in Chrome. You can adjust desired team comps by changing the `{tanks: i, dps: j, support: k}` argument passed to `getTeamPicksByHardCounterFlexRoles` in `Calculator`.

I added new labels for heroes (e.g. "dps", "tank"), they may need to be corrected for accuracy. If you need a bunch more tanks than you currently have, it will give tanks a much larger bonus until you have enough. If you have too many, then it will give tanks a penalty in its ranking.

### Example 1
Let's say you want 3 DPS and 3 tank heroes, and you have 1 DPS and no tanks selected. The algo will give a tank a larger bonus than a DPS, and DPS will have a larger bonus than a support. If you then add a tank, it will give tanks and DPS the same bonus. Now let's say you have 4 DPS selected, then it will give all tanks a higher bonus than a DPS (which are actually given a penalty).

### Example 2
Let's say you want 2 DPS, 2 tank, 2 support and you have 2 DPS and 2 tanks selected. All supports will be given a larger bonus (relative to tanks and supports). Occasionally, it will recommend heroes which aren't desired (based on your stated team comp) but the other factors (# of counters, or popularity) turns out to be much larger than the team comp bonus.